### PR TITLE
Update install_puppet_modules.sh

### DIFF
--- a/puppet/install_puppet_modules.sh
+++ b/puppet/install_puppet_modules.sh
@@ -3,7 +3,7 @@
 # Exit on any errors.
 set -e
 
-PUPPET_INSTALL='puppet module install --module_repository http://forge.puppetlabs.com'
+PUPPET_INSTALL='puppet module install '
 
 # install puppet modules
 (puppet module list | grep acme-ohmyzsh) ||


### PR DESCRIPTION
The http://forge.puppetlabs.com is redirecting to https://forge.puppet.com/ basically the `--module_repository http://forge.puppetlabs.com` is not necessary. 
