### PR TITLE
Missing python-tk dependency

### DIFF
--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -29,6 +29,10 @@ class init {
                 source => '/usr/share/autojump/autojump.sh',
                 require => Package['autojump']
             }
+            package { 'python-tk':
+                ensure => present,
+                require => Exec['apt-update'];
+            }
         }
     }
 }


### PR DESCRIPTION
Adds `python-tk` dependency to puppet module. Resolves #5.

Testing done: MNIST ipython notebook runs without errors.
